### PR TITLE
Send bzip2ed ARF reports.

### DIFF
--- a/extra/foreman_scap_client.spec
+++ b/extra/foreman_scap_client.spec
@@ -23,6 +23,7 @@ BuildRequires: rubygems-devel
 BuildRequires: ruby
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
+Requires: bzip2
 
 %description
 Client script that runs OpenSCAP scan and uploads the result to foreman proxy.

--- a/foreman_scap_client.gemspec
+++ b/foreman_scap_client.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
+  spec.requirements = '/usr/bin/bzip2'
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
Foreman_openscap receives only bzip2ed arfs.

Fixes #4.
