### PR TITLE
oscap command will return 2 when the scan is successful

### DIFF
--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -31,7 +31,7 @@ module ForemanScapClient
     def scan
       puts "DEBUG: running: " + scan_command
       result = `#{scan_command}`
-      if $?.success?
+      if $?.success? || $?.exitstatus == 2
         @report = results_path
       else
         puts 'Scan failed'


### PR DESCRIPTION
but the machine is not compliant.

The errors are reported as return 1. See man page for more details.

Btw, we may want to send a report even when 1 is returned. ~~ Otherwise
users will be surprised why the report is missing.
