### PR TITLE
client should Post instead of Put

### DIFF
--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -77,7 +77,7 @@ module ForemanScapClient
       uri = URI.parse(upload_uri)
       puts "Uploading results to #{uri}"
       https = generate_https_object(uri)
-      request = Net::HTTP::Put.new uri.path
+      request = Net::HTTP::Post.new uri.path
       request.body = File.read(results_bzip_path)
       request['Content-Type'] = 'text/xml'
       request['Content-Encoding'] = 'x-bzip2'


### PR DESCRIPTION
Should be merged when https://github.com/theforeman/smart_proxy_openscap/pull/17 is merged.
Method [changed](https://github.com/theforeman/smart_proxy_openscap/pull/17/files#diff-d9b04fc460aeec56309cdf7a9eb41a33R30) from `Put` to `Post` as it is more semantically correct.
