### PR TITLE
Fixes #25500 - Ruby 1.8.7 compatibility for RHEL6

### DIFF
--- a/foreman_scap_client.gemspec
+++ b/foreman_scap_client.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+
+  spec.add_dependency "json", "~> 1.4" if RUBY_VERSION.start_with? '1.8'
 end


### PR DESCRIPTION
Unfortunately, ruby 1.8.7 has no support for passing env variables into commands, so we need additional gem.
