### PR TITLE
Fixes #26205 - Use only HTTP proxy for scan

### DIFF
--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -56,7 +56,7 @@ module ForemanScapClient
     def run_scan
       stdout_str, error_str, result = Open3.capture3(scan_command_env_vars, scan_command)
       if result.success? || result.exitstatus == 2
-        puts error_str.split("\n").select { |item| item.start_with? 'WARNING:' }.join("\n")
+        puts error_str
         @report = results_path
       else
         puts 'Scan failed'
@@ -82,8 +82,7 @@ module ForemanScapClient
     def scan_command_env_vars
       if http_proxy_uri
         {
-          'HTTP_PROXY'  => http_proxy_uri,
-          'HTTPS_PROXY' => http_proxy_uri
+          'HTTP_PROXY'  => http_proxy_uri
         }
       else
         {}


### PR DESCRIPTION
I also print the whole error string, which shows result of remote resources download. I previously added the filter, because there was a lot of stuff that was not providing any meaningful information, but it was probably just my instance, I did not encounter it in production when fixing this.
