### PR TITLE
Adding option for specifing SSL ciphers

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -18,6 +18,8 @@
 :host_certificate: '/var/lib/puppet/ssl/certs/client.example.com.pem'
 # this client private key, usually the same that puppet agent use
 :host_private_key: '/var/lib/puppet/ssl/private_keys/client.example.com.pem'
+# optional cipher list if endpoints are hardened
+:ciphers: ["AES256-SHA:AES128-SHA:DES-CBC3-SHA"]
 
 # policy (key is id as in Foreman)
 1:

--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -171,6 +171,7 @@ module ForemanScapClient
     def generate_https_object(uri)
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
+      https.ciphers = config[:ciphers] if config[:ciphers]
       https.verify_mode = OpenSSL::SSL::VERIFY_PEER
       https.ca_file = config[:ca_file]
       begin


### PR DESCRIPTION
We are running hardened clients and current upload is failing 
Upload failed: SSL_connect returned=1 errno=0 state=error: sslv3 alert handshake failure

Having option to select proper cipher would address this.