### PR TITLE
Update base_client.rb

### DIFF
--- a/lib/foreman_scap_client/base_client.rb
+++ b/lib/foreman_scap_client/base_client.rb
@@ -188,6 +188,7 @@ module ForemanScapClient
         puts e.message
         exit(3)
       end
+      https.verify_mode = config[:ssl_verify_mode] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
       https
     end
 


### PR DESCRIPTION
This line will allow for a user to add a line to the /etc/foreman_scap_client/config.yaml file that will skip SSL verification. It is useful for testing on  trusted self signed foreman servers.