### PR TITLE
Enable local files option in OpenSCAP

### DIFF
--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -40,10 +40,10 @@ module ForemanScapClient
     end
 
     def local_files_subcommand
-      supports_local_file_option ? '--local-files /root' : ''
+      supports_local_file_option? ? '--local-files /root' : ''
     end
 
-    def supports_local_file_option
+    def supports_local_file_option?
       # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
       version = `rpm -q openscap`.split('-')[1]
       Gem::Version.new(version) >= Gem::Version.new('1.3.6') && !config[:fetch_remote_resources]

--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -40,13 +40,13 @@ module ForemanScapClient
     end
 
     def local_files_subcommand
-      supports_local_file_option? ? '--local-files /root' : ''
+      supports_local_file_option? && !config[:fetch_remote_resources] ? '--local-files /root' : ''
     end
 
     def supports_local_file_option?
       # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
       version = `rpm -q openscap`.split('-')[1]
-      Gem::Version.new(version) >= Gem::Version.new('1.3.6') && !config[:fetch_remote_resources]
+      Gem::Version.new(version) >= Gem::Version.new('1.3.6')
     end
 
     def tailoring_subcommand

--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -36,14 +36,17 @@ module ForemanScapClient
                                else
                                  ''
                                end
+      "oscap xccdf eval #{fetch_remote_resources} #{local_files_subcommand} #{profile} #{tailoring_subcommand} --results-arf #{results_path} #{config[@policy_id][:content_path]}"
+    end
+
+    def local_files_subcommand
+      supports_local_file_option ? '--local-files /root' : ''
+    end
+
+    def supports_local_file_option
       # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
       version = `rpm -q openscap`.split('-')[1]
-      local_files = if Gem::Version.new(version) >= Gem::Version.new('1.3.6') && !config[:fetch_remote_resources]
-                      '--local-files /root'
-                    else
-                      ''
-                    end
-      "oscap xccdf eval #{fetch_remote_resources} #{local_files} #{profile} #{tailoring_subcommand} --results-arf #{results_path} #{config[@policy_id][:content_path]}"
+      Gem::Version.new(version) >= Gem::Version.new('1.3.6') && !config[:fetch_remote_resources]
     end
 
     def tailoring_subcommand

--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -38,11 +38,11 @@ module ForemanScapClient
                                end
       # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
       version = `rpm -q openscap`.split('-')[1]
-      if version >= '1.3.6' and not config[:fetch_remote_resources]
-        local_files = '--local-files /root'
-      else
-        local_files = ''
-      end
+      local_files = if Gem::Version.new(version) >= Gem::Version.new('1.3.6') && !config[:fetch_remote_resources]
+                      '--local-files /root'
+                    else
+                      ''
+                    end
       "oscap xccdf eval #{fetch_remote_resources} #{local_files} #{profile} #{tailoring_subcommand} --results-arf #{results_path} #{config[@policy_id][:content_path]}"
     end
 

--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -36,7 +36,14 @@ module ForemanScapClient
                                else
                                  ''
                                end
-      "oscap xccdf eval #{fetch_remote_resources} #{profile} #{tailoring_subcommand} --results-arf #{results_path} #{config[@policy_id][:content_path]}"
+      # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
+      version = `rpm -q openscap`.split('-')[1]
+      if version >= '1.3.6' and not config[:fetch_remote_resources]
+        local_files = '--local-files /root'
+      else
+        local_files = ''
+      end
+      "oscap xccdf eval #{fetch_remote_resources} #{local_files} #{profile} #{tailoring_subcommand} --results-arf #{results_path} #{config[@policy_id][:content_path]}"
     end
 
     def tailoring_subcommand

--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -45,7 +45,8 @@ module ForemanScapClient
 
     def supports_local_file_option?
       # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
-      version = `rpm -q openscap`.split('-')[1]
+      version, _stderr, status = Open3.capture3('rpm', '-q', '--qf', '%{version}', 'openscap')
+      return false unless status.success?
       Gem::Version.new(version) >= Gem::Version.new('1.3.6')
     end
 


### PR DESCRIPTION
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2081777

This PR adds support for OpenSCAP's `--local-files` option. This option enables users to provide local copies of remote components of SCAP source data streams. 

Unfortunately, before the introduction of this option, there existed a way to to provide local copies of remote components by simply putting them into the root directory, which now isn't possible. It turned out that this was used by foreman_scap_plugin users. Therefore, this PR is attempt to fix a regression for them.

The `--local-files` option has been introduced to OpenSCAP in upstream version 1.3.6 (January 2022). It's been introduced to upstream by https://github.com/OpenSCAP/openscap/pull/1769. I found it has never been backported to older openscap versions, therefore its present only in RPM packages openscap-1.3.6-1 and greater not present in RHEL 7, in RHEL 8 since RHEL 8.6, in RHEL 9 since RHEL 9.0.

The `--local-files` option isn't recognized by older OpenSCAP versions, they fail with an error `unrecognized option '--local-files'`. The oscap command accepts both `--local-files` and `--fetch-remote-resources` at the same time, however, it isn't clear which of the 2 options take precedence. If the `--local-files` is provided but the given directory doesn't contain the file of a name matching the data stream component name, then a warning is shown, but the scan is performed normally, only the rule `security_patches_up_to_date` is notchecked as expected.

This change is based on suggestion by @ares to add --local-files /root option. This option will be added based on the version of the openscap installed, because we need to be compatible with both old and new versions of OpenSCAP at the same time.

I have tried the patch with different client systems:
RHEL 8.7 with openscap-1.3.6-5.el8_7.x86_64
RHEL 8.4 with openscap-1.3.4-7.el8_4.x86_64
RHEL 9.1 with openscap-1.3.6-4.el9.x86_64

Question: Can we rely that the users always put the local copy of remote SCAP source data streams components to /root?
