### PR TITLE
Fixes #33914 - Clear invalid byte sequences in run_scan

### DIFF
--- a/lib/foreman_scap_client/base_client.rb
+++ b/lib/foreman_scap_client/base_client.rb
@@ -81,7 +81,7 @@ module ForemanScapClient
     def run_scan
       stdout_str, error_str, result = Open3.capture3(scan_command_env_vars, scan_command)
       if result.success? || result.exitstatus == 2
-        puts error_str.split("\n").select { |item| item.start_with?('WARNING:') || item.start_with?('Downloading') }.join("\n")
+        puts error_str.scrub("?").split("\n").select { |item| item.start_with?('WARNING:') || item.start_with?('Downloading') }.join("\n")
         @report = results_path
       else
         puts 'Scan failed'


### PR DESCRIPTION
@adamruzicka, what do you think? As an alternative, we could try to `force_encode` unknown strings based on current machine's locale and then `encode` into `utf-8`, but I'm afraid that it won't work for external files.