### PR TITLE
Fixes #37435 - Avoid String#scrub for compatibility

### DIFF
--- a/lib/foreman_scap_client/base_client.rb
+++ b/lib/foreman_scap_client/base_client.rb
@@ -81,7 +81,7 @@ module ForemanScapClient
     def run_scan
       stdout_str, error_str, result = Open3.capture3(scan_command_env_vars, scan_command)
       if result.success? || result.exitstatus == 2
-        puts error_str.scrub("?").split("\n").select { |item| item.start_with?('WARNING:') || item.start_with?('Downloading') }.join("\n")
+        error_str.each_line { |item| print item if item.start_with?('WARNING:') || item.start_with?('Downloading') }
         @report = results_path
       else
         puts 'Scan failed'


### PR DESCRIPTION
with older rubies

[sudoers.txt](https://github.com/theforeman/foreman_scap_client/files/15274273/sudoers.txt)

This is the file I used for testing, if you overwrite `/etc/sudoers` with this it should make oscap emit chunks of utf-16be encoded text.

```
# ruby --version
ruby 2.0.0p648 (2015-12-16) [x86_64-linux]

# ruby -e 'File.read("sudoers.txt").scrub("?")'
-e:1:in `<main>': undefined method `scrub' for #<String:0x00000000971e40> (NoMethodError)

# ruby -e 'File.read("sudoers.txt").split("\n")'
-e:1:in `split': invalid byte sequence in US-ASCII (ArgumentError)
        from -e:1:in `<main>'

# ruby -e 'File.read("sudoers.txt").each_line { |l| print l if l.start_with? "# Default" }'
# Defaults specification
# Defaults   env_keep += "HOME"
```
