### PR TITLE
Fix compatibility with non-RPM based distributions

### DIFF
--- a/lib/foreman_scap_client/client.rb
+++ b/lib/foreman_scap_client/client.rb
@@ -45,8 +45,9 @@ module ForemanScapClient
 
     def supports_local_file_option?
       # OpenSCAP 1.3.6 and newer requires the `--local-files` option to use local copies of remote SDS components
-      version, _stderr, status = Open3.capture3('rpm', '-q', '--qf', '%{version}', 'openscap')
+      versions, _stderr, status = Open3.capture3('oscap', '--version')
       return false unless status.success?
+      version = versions.lines[0].split.last
       Gem::Version.new(version) >= Gem::Version.new('1.3.6')
     end
 


### PR DESCRIPTION
Fix https://github.com/theforeman/foreman_scap_client/issues/47

```ruby
irb(main):007:0> versions, _stderr, status = Open3.capture3('oscap', '--version')
=> ["OpenSCAP command line tool (oscap) 1.2.17\nCopyright 2009--2017 Red Hat Inc., Durham, North Carolina.\n\n==== Supported specifications ====\nXCCDF Version...
```
```ruby
irb(main):008:0> version = versions.lines[0].split.last
=> "1.2.17"
```