### PR TITLE
Fixes #37655 - Add dependency on json

### DIFF
--- a/foreman_scap_client.gemspec
+++ b/foreman_scap_client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.requirements = 'bzip2'
+  spec.add_dependency 'json'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This should get picked up when the packaging gets bumped, propagating this change into a proper dependency of the `foreman_scap_client`